### PR TITLE
Update pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,4 +11,4 @@ dependencies:
     sdk: flutter
   google_mobile_ads: ^1.0.1
   path: ^1.8.0
-  xml: ^5.1.2
+  xml: ^6.0.1


### PR DESCRIPTION
Update XML version
Because every version of flutter_ads_mediation depends on xml ^5.1.2 and flutter_svg >=1.1.0 <2.0.0-dev.2 depends on xml ^6.0.1, flutter_ads_mediation is
  incompatible with flutter_svg >=1.1.0 <2.0.0-dev.2.
So, because bedrive depends on both flutter_svg ^1.1.6 and flutter_ads_mediation ^1.3.1, version solving failed.